### PR TITLE
[ci] fixes #2 - Github templates : issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,27 @@
+
+Issue tracker is **ONLY** used for reporting bugs, features and enhancements. NO SUPPORT TICKETS ACCEPTED! Use [stackoverflow](https://stackoverflow.com) for supporting issues.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+


### PR DESCRIPTION
Fixes #2

Changes:
- Github issue templates

Does this change need to mentioned in CHANGELOG.md?

No

